### PR TITLE
feat: add include task option for single org export script [BB-5406]

### DIFF
--- a/exporter/single_org_config.py
+++ b/exporter/single_org_config.py
@@ -30,6 +30,8 @@ def _get_config(program_options):
     merge_program_options(config, program_options)
 
     update_exclude_tasks(config)
+    
+    update_include_tasks(config)
 
     set_config_defaults(config)
 
@@ -92,6 +94,17 @@ def update_exclude_tasks(config):
         del values['exclude_task']
 
     values['exclude_tasks'] = exclude_tasks
+
+def update_include_tasks(config):
+    values = config['values']
+
+    tasks = values.get('include_task', [])
+
+    if 'include_task' in values:
+        del values['include_task']
+
+    if tasks:
+        values['tasks'] = tasks
 
 
 def get_config_for_course(config, course):

--- a/exporter/single_org_export.py
+++ b/exporter/single_org_export.py
@@ -4,7 +4,7 @@
 Export course data.
 
 Usage:
-  single-org-exporter [options] [--exclude-task=<task>...]
+  single-org-exporter [options] [--exclude-task=<task>...] [--include-task=<task>...]
 
 Options:
   -h --help                  Show this screen.
@@ -34,6 +34,8 @@ Options:
   --mongo-password=<password>       The mongo password to connect
   --mongo-db=<db>                   The mongo db to query
   --mongo-collection=<collection>   The mongo collection to query
+  --mongo-auth-db=<auth-db>         The mongo auth db
+  --mongo-options=<options>         Mongo connection string options
 
   --sql-host=<host>         The sql db host
   --sql-user=<user>         The sql username for login to db
@@ -45,6 +47,8 @@ Options:
   --organization=<org-name> The name of the organization
 
   --exclude-task=<task>     Specify task NOT to run.
+
+  --include-task=<task>     Specify task to run. If nothing specified, all tasks are run.
 """
 
 

--- a/exporter/tasks.py
+++ b/exporter/tasks.py
@@ -175,11 +175,25 @@ class MongoTask(Task):
     @classmethod
     def constructMongoURI(*args, **kwargs):
         uri = "mongodb://"
-        
-        if kwargs.get("mongo_user") and kwargs.get("mongo_password"):
-            uri = f"{uri}{kwargs.get('mongo_user').strip()}:{kwargs.get('mongo_password').strip()}@"
 
-        return f"{uri}{kwargs.get('mongo_host')}/{kwargs.get('mongo_db')}"
+        mongo_host = kwargs.get('mongo_host')
+        mongo_user = kwargs.get('mongo_user')
+        mongo_password = kwargs.get('mongo_password')
+        mongo_auth_db = kwargs.get('mongo_auth_db')
+        mongo_options = kwargs.get('mongo_options')
+
+        if mongo_user and mongo_password:
+            uri = f"{uri}{mongo_user}:{mongo_password}@"
+
+        uri = f"{uri}{mongo_host}/"
+
+        if mongo_auth_db:
+            uri = f"{uri}{mongo_auth_db}"
+
+        if mongo_options:
+            uri = f"{uri}?{mongo_options}"
+
+        return uri
 
     @classmethod
     def run(cls, filename, dry_run, **kwargs):
@@ -191,10 +205,13 @@ class MongoTask(Task):
 
         log.debug(query)
 
+        mongo_db_name = kwargs.get("mongo_db")
+        mongo_collection = kwargs.get("mongo_collection")
+
         if dry_run:
             print('MONGO: {0}'.format(query))
         else:
-            collection = MongoClient(mongo_uri)[kwargs.get("mongo_db")][kwargs.get("mongo_collection")]
+            collection = MongoClient(mongo_uri)[mongo_db_name][mongo_collection]
             cursor = collection.find(json.loads(query))
             with open(filename, 'w') as file:
                 for document in cursor:


### PR DESCRIPTION
## Description

This PR adds the option to only include certains tasks for execution in the script for export of course data for single org.

Additionally, it adds the option to include mongo auth_db and mongo connection string options as well.


## Supporting information

[BB-5406](https://tasks.opencraft.com/browse/BB-5406)

The changes here have been added to a seperate [Upstream PR](https://github.com/openedx/edx-analytics-exporter/pull/59) as well
